### PR TITLE
adding rcrossref as import

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,7 @@ Imports:
    tibble,
    bibliometrix, 
    crminer,
+   rcrossref,
    xml2,
    rvest,
    jsonlite


### PR DESCRIPTION
rcrossref is only a suggestion for crminer, so I explicitly added it as a dependence for BibScan