### PR TITLE
fixing title_to_doi adding stringr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ Imports:
    purrr,
    readr,
    tibble,
+   stringr,
    bibliometrix, 
    crminer,
    rcrossref,

--- a/R/article_pdf_download.R
+++ b/R/article_pdf_download.R
@@ -35,11 +35,13 @@ article_pdf_download <- function(infilepath, outfilepath = infilepath, colandr=N
 
   # Join the DOI to Colandr output (https://www.colandrcommunity.com)
   if(is.null(colandr) == F){
+
+    print("in the condition")
     # Read sorted list from Colandr
     papers <- readr::read_csv(file.path(colandr))
-
+    print("before title_to_doi call")
     # Match titles from Colandr to DOIs from .bib
-    matched <- title_to_doi(papers,df_citations,cond)
+    matched <- title_to_doi(papers, df_citations, cond)
 
   }else{
     matched <- df_citations

--- a/R/title_to_doi.R
+++ b/R/title_to_doi.R
@@ -13,9 +13,7 @@
 #' @return A data frame of titles, journals, authors, and DOIs in the .bib format
 #'
 #' @examples title_to_doi()
-title_to_doi <- function(papers,file_list,condition){
-  # require(bibliometrix)
-  # require(tidyverse)
+title_to_doi <- function(papers, file_list, condition){
 
   # filter list of papers by those that are included
   # select only the relevant columns
@@ -31,7 +29,7 @@ title_to_doi <- function(papers,file_list,condition){
   references$TI <- tolower(references$TI)
 
   # remove extra spaces in .bib data frame
-  references$TI <- gsub("\\s+", " ", str_trim(references$TI))
+  references$TI <- gsub("\\s+", " ", stringr::str_trim(references$TI))
 
   # merge the two data sets
   # remove duplications


### PR DESCRIPTION
fixing the error  ( #18 ) within `title_to_doi` due to the missing namespace for `str_trim` 

Also added stringr as dependency in the DESCRIPTION file

And some small other syntax changes