### PR TITLE
Fix file paths, add file name, add empty directory check, update summary report

### DIFF
--- a/R/article_pdf_download.R
+++ b/R/article_pdf_download.R
@@ -6,6 +6,7 @@
 #' @param bib_format  (character) format used by the bibtex file
 #' @param colandr     A file (character) that provides titles to match; designed to be output of Colandr
 #' @param cond        Condition (logical) that defines sorting of output from Colandr file
+#' @param overwrite   Condition (logical) that determines whether to overwrite contents of outfilepath, if it's nonempty
 #'
 #' @return data frame containing dowload information
 #'
@@ -15,12 +16,16 @@
 #' @export
 #' @examples \dontrun{ article_pdf_download(infilepath = "/data/isi_searches", outfilepath = "data")}
 
-article_pdf_download <- function(infilepath, outfilepath = infilepath, bib_format = "soc_bib", colandr=NULL, cond="included"){
+article_pdf_download <- function(infilepath, outfilepath = infilepath, bib_format = "soc_bib", colandr=NULL, cond="included", overwrite = FALSE){
   # ===============================
   # CONSTANTS
   # ===============================
-  # Create the main output directory
-  dir.create(outfilepath, showWarnings = FALSE)
+  # give error if overwrite is false AND the directory is nonempty
+  if(!overwrite & length(list.files(outfilepath, all.files = TRUE)) != 0){
+    stop("outfilepath not empty! Set overwrite = TRUE or change outfilepath")
+  } else{
+    dir.create(outfilepath, showWarnings = FALSE)
+    }
 
   # PDF subdirectory
   pdf_output_dir <- file.path(outfilepath, 'pdfs')

--- a/R/bib_reader.R
+++ b/R/bib_reader.R
@@ -29,7 +29,7 @@ bibfile_reader <- function(isi_dir, formatting){
     purrr::map_dfr(as.data.frame)
 
   # read the lookup table to match fields
-  lut <- readr::read_csv("inst/LUT_non_isi.csv")
+  lut <- readr::read_csv(system.file("LUT_non_isi.csv", package = "BibScan"))
   # Check if the necessary fields are here
   stopifnot(sum(lut[[formatting]] %in% names(biblio_data)) == 5)
 


### PR DESCRIPTION
### `bib_reader.R`
* fixed bug in `bib_reader` where file wouldn't load because path wasn't specified

### `article_pdf_download.R`
* added titles to downloaded files in form "*firstauthor_publicationyear_doi*", with backslashes in doi doi replaced with ".."
* added parameter `overwrite` to make sure that user is ok with overwriting `outputfilepath`
* added `is_empty` column to the summary report to check if the downloaded files are empty, and moves the empty files to the `non_pdfs` folder.